### PR TITLE
Conf.d

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ To install the server extension, run the following in your terminal:
 pip install jupyterlab_latex
 ```
 
+If you are running Notebook 5.2 or earlier, enable the server extension by running
+```bash
+jupyter serverextension enable --sys-prefix jupyterlab_latex
+```
+
 To install the lab extension, run
 ```bash
 jupyter labextension install jupyterlab-latex
@@ -38,9 +43,13 @@ You can also install from source in order to develop the extension.
 From the `jupyterlab-latex` directory, enter the following into your terminal:
 ```bash
 pip install .
-jupyter serverextension enable jupyterlab_latex
 ```
 This installs the server extension.
+
+If you are running Notebook 5.2 or earlier, enable the server extension by running
+```bash
+jupyter serverextension enable --sys-prefix jupyterlab_latex
+```
 
 Then, to install the lab extension, run
 ```bash

--- a/jupyter-config/jupyter_notebook_config.d/jupyterlab_latex.json
+++ b/jupyter-config/jupyter_notebook_config.d/jupyterlab_latex.json
@@ -1,0 +1,7 @@
+{
+  "NotebookApp": {
+    "nbserver_extensions": {
+      "jupyterlab_latex": true
+    }
+  }
+}

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,24 @@ Setup module for the jupyterlab-latex
 from __future__ import print_function
 
 import setuptools
-from setupbase import ensure_python
+from setupbase import (
+    create_cmdclass, ensure_python, find_packages
+    )
+
+ensure_python(['>=3.6'])
+
+data_files_spec = [
+    ('etc/jupyter/jupyter_notebook_config.d',
+     'jupyter-config/jupyter_notebook_config.d', 'jupyterlab_latex.json'),
+]
+
+cmdclass = create_cmdclass(data_files_spec=data_files_spec)
 
 setup_dict = dict(
     name='jupyterlab_latex',
     description='A Jupyter Notebook server extension which acts as an endpoint for LaTeX.',
-    packages=setuptools.find_packages(),
+    packages=find_packages(),
+    cmdclass=cmdclass,
     author          = 'Jupyter Development Team',
     author_email    = 'jupyter@googlegroups.com',
     url             = 'http://jupyter.org',
@@ -27,8 +39,7 @@ setup_dict = dict(
     ],
     install_requires=[
         'notebook'
-    ],
-    package_data={'jupyterlab_latex':['api/*']},
+    ]
 )
 
 try:
@@ -42,8 +53,8 @@ except ValueError as e:
 
 from jupyterlab_latex import __version__
 
-        
-    
+
+
 
 setuptools.setup(
     version=__version__,

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,6 @@ from setupbase import (
     create_cmdclass, ensure_python, find_packages
     )
 
-ensure_python(['>=3.6'])
-
 data_files_spec = [
     ('etc/jupyter/jupyter_notebook_config.d',
      'jupyter-config/jupyter_notebook_config.d', 'jupyterlab_latex.json'),
@@ -52,9 +50,6 @@ except ValueError as e:
                      )
 
 from jupyterlab_latex import __version__
-
-
-
 
 setuptools.setup(
     version=__version__,

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,11 @@ from setupbase import (
     create_cmdclass, ensure_python, find_packages
     )
 
-data_files_spec = [
-    ('etc/jupyter/jupyter_notebook_config.d',
-     'jupyter-config/jupyter_notebook_config.d', 'jupyterlab_latex.json'),
-]
+data_files_spec = [(
+    'etc/jupyter/jupyter_notebook_config.d',
+    'jupyter-config/jupyter_notebook_config.d',
+    'jupyterlab_latex.json'
+),]
 
 cmdclass = create_cmdclass(data_files_spec=data_files_spec)
 
@@ -37,7 +38,8 @@ setup_dict = dict(
     ],
     install_requires=[
         'notebook'
-    ]
+    ],
+    package_data={'jupyterlab_latex':['api/*']},
 )
 
 try:


### PR DESCRIPTION
Obviates the need for `jupyter serverextension enable jupyterlab_latex` in notebook 5.3 or later.