### PR TITLE
Disable write18

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,14 @@ c.LatexConfig.bibtex_command = '<custom_bib_command>'
 ```
 
 LaTeX files have the ability to run arbitrary code by triggering external
-shell commands. This is a security risk and is disabled by default.
-You can force it to be enabled by setting
+shell commands. This is a security risk, and so most LaTeX distributions
+restrict the commands that you can run in the shell.
+
+You can customize the behavior by setting the `LatexConfig.shell_escape` value.
+It can take three values: `"restricted"` (default) to allow only commands
+considered safe to be executed, `"allow"` to allow all commands, and `"disallow"`
+to disallow all commands.
+For example, to force your LaTeX distribution to run any command, use:
 ```python
-c.LatexConfig.allow_shell_escape = True
+c.LatexConfig.shell_escape = "allow"
 ```

--- a/README.md
+++ b/README.md
@@ -66,3 +66,17 @@ your `jupyter_notebook_config.py` file:
 ```python
 c.LatexConfig.latex_command = 'pdflatex'
 ```
+
+The extension defaults to running `bibtex` for generating a bibliography
+if a `.bib` file is found. You can also configure the bibliography command
+by setting
+```python
+c.LatexConfig.bibtex_command = '<custom_bib_command>'
+```
+
+LaTeX files have the ability to run arbitrary code by triggering external
+shell commands. This is a security risk and is disabled by default.
+You can force it to be enabled by setting
+```python
+c.LatexConfig.allow_shell_escape = True
+```

--- a/jupyterlab_latex/__init__.py
+++ b/jupyterlab_latex/__init__.py
@@ -112,14 +112,14 @@ class LatexHandler(APIHandler):
             escape_flag = '-no-shell-escape'
         elif c.shell_escape == 'restricted':
             escape_flag = '-shell-restricted'
-        full_latex_sequence = [
+        full_latex_sequence = (
             c.latex_command,
             escape_flag,
             "-interaction=nonstopmode",
             "-halt-on-error",
             "-file-line-error",
             f"{tex_base_name}"
-            ]
+            )
 
         full_bibtex_sequence = (
             c.bib_command,

--- a/jupyterlab_latex/__init__.py
+++ b/jupyterlab_latex/__init__.py
@@ -13,7 +13,7 @@ from tornado.httputil import url_concat
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest, HTTPError
 from tornado.process import Subprocess, CalledProcessError
 
-from traitlets import Unicode
+from traitlets import Unicode, Bool
 from traitlets.config import Configurable
 
 from notebook.utils import url_path_join
@@ -75,6 +75,9 @@ class LatexConfig(Configurable):
         help='The LaTeX command to use when compiling ".tex" files.')
     bib_command = Unicode('bibtex', config=True,
         help='The BibTeX command to use when compiling ".tex" files.')
+    allow_shell_escape = Bool(False, config=True,
+        help='Whether to allow shell escapes '+\
+             '(and by extension, arbitrary code execution)')
 
 
 class LatexHandler(APIHandler):
@@ -101,6 +104,7 @@ class LatexHandler(APIHandler):
 
         full_latex_sequence = (
             c.latex_command,
+            "-shell-escape" if c.allow_shell_escape else "-no-shell-escape",
             "-interaction=nonstopmode",
             "-halt-on-error",
             "-file-line-error",

--- a/jupyterlab_latex/__init__.py
+++ b/jupyterlab_latex/__init__.py
@@ -110,16 +110,14 @@ class LatexHandler(APIHandler):
             escape_flag = '-shell-escape'
         if c.shell_escape == 'disallow':
             escape_flag = '-no-shell-escape'
-        full_latex_sequence = [
+        full_latex_sequence = list(filter(lambda x: x != '', [
             c.latex_command,
+            escape_flag,
             "-interaction=nonstopmode",
             "-halt-on-error",
             "-file-line-error",
-            ]
-        if escape_flag != '':
-            full_latex_sequence.append(escape_flag)
-
-        full_latex_sequence.append(f"{tex_base_name}")
+            f"{tex_base_name}"
+            ]))
 
         full_bibtex_sequence = (
             c.bib_command,

--- a/jupyterlab_latex/__init__.py
+++ b/jupyterlab_latex/__init__.py
@@ -108,16 +108,18 @@ class LatexHandler(APIHandler):
         escape_flag = ''
         if c.shell_escape == 'allow':
             escape_flag = '-shell-escape'
-        if c.shell_escape == 'disallow':
+        elif c.shell_escape == 'disallow':
             escape_flag = '-no-shell-escape'
-        full_latex_sequence = list(filter(lambda x: x != '', [
+        elif c.shell_escape == 'restricted':
+            escape_flag = '-shell-restricted'
+        full_latex_sequence = [
             c.latex_command,
             escape_flag,
             "-interaction=nonstopmode",
             "-halt-on-error",
             "-file-line-error",
             f"{tex_base_name}"
-            ]))
+            ]
 
         full_bibtex_sequence = (
             c.bib_command,

--- a/jupyterlab_latex/__init__.py
+++ b/jupyterlab_latex/__init__.py
@@ -1,7 +1,7 @@
-import re
+""" JupyterLab LaTex : live LaTeX editing for JupyterLab """
+
 import json
 import os
-import subprocess
 import glob
 import re
 
@@ -26,27 +26,27 @@ __version__ = '0.1.0'
 @contextmanager
 def latex_cleanup(workdir='.', whitelist=None, greylist=None):
     """Context manager for changing directory and removing files when done.
-    
-    By default it works in the current directory, and removes all files that 
+
+    By default it works in the current directory, and removes all files that
     were not present in the working directory.
-    
+
     Parameters
     ----------
-    
+
     workdir = string, optional
         This represents a path to the working directory for running LaTeX (the
         default is '.').
     whitelist = list or None, optional
-        This is the set of files not present before running the LaTeX commands 
+        This is the set of files not present before running the LaTeX commands
         that are not to be removed when cleaning up. Defaults to None.
     greylist = list or None, optional
-        This is the set of files that need to be removed before running LaTeX 
-        commands but which, if present, will not by removed when cleaning up. 
+        This is the set of files that need to be removed before running LaTeX
+        commands but which, if present, will not by removed when cleaning up.
         Defaults to None.
     """
     orig_work_dir = os.getcwd()
     os.chdir(os.path.abspath(workdir))
-    
+
     keep_files = set()
     for fp in greylist:
         try:
@@ -56,7 +56,7 @@ def latex_cleanup(workdir='.', whitelist=None, greylist=None):
             pass
 
     before = set(glob.glob("*"))
-    keep_files = keep_files.union(before, 
+    keep_files = keep_files.union(before,
                                   set(whitelist if whitelist else [])
                                   )
     yield
@@ -81,24 +81,24 @@ class LatexHandler(APIHandler):
     """
     A handler that runs LaTeX on the server.
     """
-    
-    
+
+
     def build_tex_cmd_sequence(self, tex_base_name, run_bibtex=False):
         """Builds tuples that will be used to call LaTeX shell commands.
-        
+
         Parameters
         ----------
         tex_base_name: string
-            This is the name of the tex file to be compiled, without its 
+            This is the name of the tex file to be compiled, without its
             extension.
-            
+
         returns:
             A list of tuples of strings to be passed to
             `tornado.process.Subprocess`.
-            
+
         """
         c = LatexConfig(config=self.config)
-        
+
         full_latex_sequence = (
             c.latex_command,
             "-interaction=nonstopmode",
@@ -110,60 +110,60 @@ class LatexHandler(APIHandler):
             c.bib_command,
             f"{tex_base_name}",
             )
-            
+
         command_sequence = [tuple(full_latex_sequence)]
-        
+
         if run_bibtex:
             command_sequence += [
-                tuple(full_bibtex_sequence), 
-                tuple(full_latex_sequence), 
+                tuple(full_bibtex_sequence),
+                tuple(full_latex_sequence),
                 tuple(full_latex_sequence),
                 ]
-                
+
         return command_sequence
-                    
+
     def bib_condition(self):
         """Determines whether BiBTeX should be run.
-        
+
         Returns
         -------
         boolean
             true if BibTeX should be run.
-            
+
         """
         return any([re.match(r'.*\.bib', x) for x in set(glob.glob("*"))])
 
-    
+
     @web.authenticated
     @gen.coroutine
     def run_latex(self, command_sequence):
         """Run commands sequentially, returning a 500 code on an error.
-        
+
         Parameters
         ----------
         command_sequence : list of tuples of strings
             This is a sequence of tuples of strings to be passed to
             `tornado.process.Subprocess`, which are to be run sequentially.
-        
+
         Returns
         -------
         string
-            Response is either a success or an error string. 
-        
+            Response is either a success or an error string.
+
         Raises
         ------
         tornado.process.CalledProcessError
-        
+
         Notes
         -----
         - LaTeX processes only print to stdout, so errors are gathered from
           there.
-        
+
         """
         for cmd in command_sequence:
             process = Subprocess(cmd, 
-                                 stdout=Subprocess.STREAM, 
-                                 stderr=Subprocess.STREAM) 
+                                 stdout=Subprocess.STREAM,
+                                 stderr=Subprocess.STREAM)
             try:
                 yield process.wait_for_exit()
             except CalledProcessError as err:
@@ -173,10 +173,10 @@ class LatexHandler(APIHandler):
                                + str(err.returncode))
                 out = yield process.stdout.read_until_close()
                 return out
-                
+
         return "LaTeX compiled"
 
-    
+
     @gen.coroutine
     def get(self, path = ''):
         """
@@ -185,7 +185,7 @@ class LatexHandler(APIHandler):
         # Get access to the notebook config object
         tex_file_path = os.path.abspath(path.strip('/'))
         tex_base_name, ext = os.path.splitext(os.path.basename(tex_file_path))
-        
+
         if not os.path.exists(tex_file_path):
             self.set_status(404)
             out = f"There is no file at `{tex_file_path}`."
@@ -200,7 +200,7 @@ class LatexHandler(APIHandler):
                 greylist=[tex_base_name+'.aux']
                 ):
                 bibtex = self.bib_condition()
-                cmd_sequence = self.build_tex_cmd_sequence(tex_base_name, 
+                cmd_sequence = self.build_tex_cmd_sequence(tex_base_name,
                                                            run_bibtex=bibtex)
                 out = yield self.run_latex(cmd_sequence)
         self.finish(out)


### PR DESCRIPTION
It looks like most LaTeX distributions disable write18 by default, so the security risk for arbitrary code execution is already mitigated by that. This exposes an option for making that behavior explicit.