### PR TITLE
Error refactor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,8 @@ import {
 } from '@jupyterlab/application';
 
 import {
-  InstanceTracker
+  InstanceTracker,
+  showErrorMessage
 } from '@jupyterlab/apputils';
 
 import {
@@ -126,9 +127,17 @@ function activateLatexPlugin(app: JupyterLab, manager: IDocumentManager, editorT
       pdfContext.disposed.connect(cleanupPreviews);
     };
 
-    const errorPanelInit = ( err: ServerConnection.ResponseError ) => {
+    const errorPanelInit = (err: ServerConnection.ResponseError) => {
       if (err.response.status === 404) {
-        throw err;
+        const noServerExt = {
+          message: 'You probably do not have jupyterlab_latex '
+                   + 'installed or enabled. '
+                   + 'Please, run "pip install -U jupyterlab_latex." '
+                   + 'If that does not work, try "jupyter serverextension '
+                   + 'enable --sys-prefix jupyterlab_latex".'
+        };
+        showErrorMessage('Server Extension Error', noServerExt);
+        return;
       }
 
       errorPanel = Private.createErrorPanel();

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,7 @@ function activateLatexPlugin(app: JupyterLab, manager: IDocumentManager, editorT
       pdfContext.disposed.connect(cleanupPreviews);
     };
 
-    const errorPanelInit = (err: ServerConnection.ResponseError ) => {
+    const errorPanelInit = ( err: ServerConnection.ResponseError ) => {
       if (err.response.status === 404) {
         throw err;
       }
@@ -141,6 +141,7 @@ function activateLatexPlugin(app: JupyterLab, manager: IDocumentManager, editorT
         ref: widget.id,
         mode: 'split-bottom'
       });
+      errorPanel.text = err.message;
     };
 
     // Hook up an event listener for when the '.tex' file is saved.
@@ -162,7 +163,6 @@ function activateLatexPlugin(app: JupyterLab, manager: IDocumentManager, editorT
         if (!errorPanel) {
           errorPanelInit(err);
         }
-        errorPanel.text = err.message;
         pending = false;
       });
     };
@@ -177,7 +177,6 @@ function activateLatexPlugin(app: JupyterLab, manager: IDocumentManager, editorT
     }).catch((err) => {
       // If there was an error, show the error panel
       // with the error log.
-      errorPanel.text = err.message;
       errorPanelInit(err);
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,11 @@ function activateLatexPlugin(app: JupyterLab, manager: IDocumentManager, editorT
       pdfContext.disposed.connect(cleanupPreviews);
     };
 
-    const errorPanelInit = () => {
+    const errorPanelInit = (err: ServerConnection.ResponseError ) => {
+      if (err.response.status === 404) {
+        throw err;
+      }
+
       errorPanel = Private.createErrorPanel();
       // On disposal, set the reference to null
       errorPanel.disposed.connect(() => {
@@ -156,7 +160,7 @@ function activateLatexPlugin(app: JupyterLab, manager: IDocumentManager, editorT
         // If there was an error, show the error panel
         // with the error log.
         if (!errorPanel) {
-          errorPanelInit();
+          errorPanelInit(err);
         }
         errorPanel.text = err.message;
         pending = false;
@@ -173,8 +177,8 @@ function activateLatexPlugin(app: JupyterLab, manager: IDocumentManager, editorT
     }).catch((err) => {
       // If there was an error, show the error panel
       // with the error log.
-      errorPanelInit();
       errorPanel.text = err.message;
+      errorPanelInit(err);
     });
 
     const cleanupPreviews = () => {


### PR DESCRIPTION
refactor to the errorPanelInit so we can not print an error when the serverextension is not available…

Right now we're just propagating the error up, but we could also display something saying that the serverextension was not found (an alert or something?; I tend to not like them but this does seem like an appropriate use case)

