### PR TITLE
Add keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "keywords": [
     "jupyter",
     "jupyterlab",
+    "jupyterlab-extension",
     "latex"
   ],
   "jupyterlab": {


### PR DESCRIPTION
Adds a `jupyterlab-extension` keyword for better discoverability on npm.org