### PR TITLE
Bump for bugfix that was preventing binder from working.

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,3 +1,3 @@
-jupyterlab==0.31.2
+jupyterlab==0.31.5
 jupyterlab_latex==0.2.0
 notebook==5.3


### PR DESCRIPTION
JLab v0.31.2 had a bug that was preventing binder from working.