### PR TITLE
Synctex

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Subsequent saves of the file will automatically update the PDF.
 If the PDF fails to compile (possibly due to a syntax error),
 an error panel will open detailing the LaTeX error.
 
+For more advanced usage documentation, see [here](docs/advanced.md).
+
 ## Requirements
 
 * JupyterLab 0.31
@@ -41,28 +43,6 @@ To install the lab extension, run
 jupyter labextension install @jupyterlab/latex
 ```
 
-## Installing from source
-
-You can also install from source in order to develop the extension.
-
-From the `jupyterlab-latex` directory, enter the following into your terminal:
-```bash
-pip install .
-```
-This installs the server extension.
-
-If you are running Notebook 5.2 or earlier, enable the server extension by running
-```bash
-jupyter serverextension enable --sys-prefix jupyterlab_latex
-```
-
-Then, to install the lab extension, run
-```bash
-jlpm install
-jlpm run build
-jupyter labextension install .
-```
-
 ## Customization
 
 The extension defaults to running `xelatex` on the server.
@@ -77,17 +57,4 @@ if a `.bib` file is found. You can also configure the bibliography command
 by setting
 ```python
 c.LatexConfig.bibtex_command = '<custom_bib_command>'
-```
-
-LaTeX files have the ability to run arbitrary code by triggering external
-shell commands. This is a security risk, and so most LaTeX distributions
-restrict the commands that you can run in the shell.
-
-You can customize the behavior by setting the `LatexConfig.shell_escape` value.
-It can take three values: `"restricted"` (default) to allow only commands
-considered safe to be executed, `"allow"` to allow all commands, and `"disallow"`
-to disallow all commands.
-For example, to force your LaTeX distribution to run any command, use:
-```python
-c.LatexConfig.shell_escape = "allow"
 ```

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,59 @@
+# Advanced usage
+
+## Using SyncTeX
+
+JupyterLab LaTeX supports using SyncTeX to map a location in the
+text editor to a location in the generated PDF, as well as the reverse.
+To reveal the page of the PDF correspoding to the cursor in the text editor,
+right-click in the editor and select "Show ".
+To reveal the location in the text editor corresponding to a page of the PDF,
+right click on the PDF and select "Scroll PDF to Cursor"
+
+SyncTeX generates its mapping during the compilation of the `.tex` document
+and stores it in a `.synctex.gz` file.
+If you subsequently edit the `.tex` document and run SyncTeX
+before it recompiles, it may return incorrect results.
+
+You can disable SyncTeX support by setting `synctex: false`
+in the JupyterLab advanced settings editor.
+The extension defaults to running `synctex` for establishing the mapping.
+You can configure this command by setting `c.LatexConfig.synctex_command`
+in your `jupyter_notebook_config.py` file.
+
+## Security and customizing shell escapes
+
+LaTeX files have the ability to run arbitrary code by triggering external
+shell commands. This is a security risk, and so most LaTeX distributions
+restrict the commands that you can run in the shell.
+
+You can customize the behavior by setting the `LatexConfig.shell_escape` value.
+It can take three values: `"restricted"` (default) to allow only commands
+considered safe to be executed, `"allow"` to allow all commands, and `"disallow"`
+to disallow all commands.
+For example, to force your LaTeX distribution to run any command, use:
+```python
+c.LatexConfig.shell_escape = "allow"
+```
+
+## Installing from source
+
+You can install from source in order to develop the extension.
+
+From the `jupyterlab-latex` directory, enter the following into your terminal:
+```bash
+pip install -e .
+```
+This installs the server extension.
+
+If you are running Notebook 5.2 or earlier, enable the server extension by running
+```bash
+jupyter serverextension enable --sys-prefix jupyterlab_latex
+```
+
+Then, to install the lab extension, run
+```bash
+jlpm install
+jlpm run build
+jupyter labextension install .
+```
+

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -4,6 +4,10 @@
 
 JupyterLab LaTeX supports using SyncTeX to map a location in the
 text editor to a location in the generated PDF, as well as the reverse.
+In the forward direction, it takes a line and column from the `.tex` file,
+and maps it to a page in the PDF, as well as an (x,y) position on the page.
+In the reverse direction, it takes a page and an (x,y) position, and maps
+it onto a line and column of the `.tex` document.
 To reveal the page of the PDF correspoding to the cursor in the text editor,
 right-click in the editor and select "Show ".
 To reveal the location in the text editor corresponding to a page of the PDF,
@@ -11,6 +15,9 @@ right click on the PDF and select "Scroll PDF to Cursor"
 
 SyncTeX generates its mapping during the compilation of the `.tex` document
 and stores it in a `.synctex.gz` file.
+The `.synctex.gz` file is gzipped, as it can be large for long `.tex` documents.
+It is used by the `synctex` command line program,
+and is not intended to be used or parsed by users or developers.
 If you subsequently edit the `.tex` document and run SyncTeX
 before it recompiles, it may return incorrect results.
 

--- a/jupyterlab_latex/__init__.py
+++ b/jupyterlab_latex/__init__.py
@@ -85,7 +85,7 @@ class LatexConfig(Configurable):
         'to disallow all shell escapes')
 
 
-class LatexHandler(APIHandler):
+class LatexBuildHandler(APIHandler):
     """
     A handler that runs LaTeX on the server.
     """
@@ -291,9 +291,12 @@ def load_jupyter_server_extension(nb_server_app):
     web_app = nb_server_app.web_app
     # Prepend the base_url so that it works in a jupyterhub setting
     base_url = web_app.settings['base_url']
-    endpoint = url_path_join(base_url, 'latex')
-    handlers = [(f'{endpoint}{path_regex}', 
-                 LatexHandler, 
+    latex = url_path_join(base_url, 'latex')
+    build = url_path_join(latex, 'build')
+    sync = url_path_join(latex, 'synctex')
+
+    handlers = [(f'{build}{path_regex}',
+                 LatexBuildHandler,
                  {"notebook_dir": nb_server_app.notebook_dir}
                 )]
     web_app.add_handlers('.*$', handlers)

--- a/jupyterlab_latex/__init__.py
+++ b/jupyterlab_latex/__init__.py
@@ -120,13 +120,18 @@ class LatexBuildHandler(APIHandler):
         elif c.shell_escape == 'restricted':
             escape_flag = '-shell-restricted'
 
+        # Get the synctex query parameter, defaulting to
+        # 1 if it is not set or is invalid.
+        synctex = self.get_query_argument('synctex', default='1')
+        synctex = '1' if synctex != '0' else synctex
+
         full_latex_sequence = (
             c.latex_command,
             escape_flag,
             "-interaction=nonstopmode",
             "-halt-on-error",
             "-file-line-error",
-            "-synctex=1",
+            f"-synctex={synctex}",
             f"{tex_base_name}",
             )
 

--- a/jupyterlab_latex/__init__.py
+++ b/jupyterlab_latex/__init__.py
@@ -219,7 +219,7 @@ class LatexBuildHandler(APIHandler):
         else:
             with latex_cleanup(
                 workdir=os.path.dirname(tex_file_path),
-                whitelist=[tex_base_name+'.pdf', tex_base_name+'synctex.gz'],
+                whitelist=[tex_base_name+'.pdf', tex_base_name+'.synctex.gz'],
                 greylist=[tex_base_name+'.aux']
                 ):
                 bibtex = self.bib_condition()
@@ -371,6 +371,9 @@ class LatexSynctexHandler(APIHandler):
         if not os.path.exists(full_file_path):
             self.set_status(403)
             out = f"Request cannot be completed; no file at `{full_file_path}`."
+        elif not os.path.exists(os.path.join(workdir, base_name + '.synctex.gz')):
+            self.set_status(403)
+            out = f"Request cannot be completed; no SyncTeX file found in `{workdir}`."
         elif ext != '.tex' and ext != '.pdf':
             self.set_status(400)
             out = (f"The file `{ext}` does not end with .tex of .pdf. "

--- a/jupyterlab_latex/__init__.py
+++ b/jupyterlab_latex/__init__.py
@@ -316,7 +316,6 @@ class LatexSynctexHandler(APIHandler):
             if started:
                 vals = line.split(':')
                 result[vals[0].strip()] = vals[1].strip()
-                self.log.info(str(vals))
         return result
 
 

--- a/jupyterlab_latex/__init__.py
+++ b/jupyterlab_latex/__init__.py
@@ -204,8 +204,7 @@ class LatexBuildHandler(APIHandler):
         """
         Given a path, run LaTeX, cleanup, and respond when done.
         """
-
-        # Get access to the notebook config object
+        # Parse the path into the base name and extension of the file
         tex_file_path = os.path.join(self.notebook_dir, path.strip('/'))
         tex_base_name, ext = os.path.splitext(os.path.basename(tex_file_path))
 
@@ -333,7 +332,7 @@ class LatexSynctexHandler(APIHandler):
         """
         Given a path, run SyncTex, and respond when done.
         """
-        # Get access to the notebook config object
+        # Parse the path into the base name and extension of the file
         full_file_path = os.path.join(self.notebook_dir, path.strip('/'))
         workdir = os.path.dirname(full_file_path)
         base_name, ext = os.path.splitext(os.path.basename(full_file_path))

--- a/jupyterlab_latex/api/api.yaml
+++ b/jupyterlab_latex/api/api.yaml
@@ -5,9 +5,9 @@ info:
   version: 0.1.0
   
 paths:
-  /latex/{filePath}:
+  /latex/build/{filePath}:
     get:
-      summary: triggers a compilation on the .tex file located at the filePath.
+      summary: Triggers a compilation on the .tex file located at the filePath.
       parameters:
         - name: filePath
           in: path
@@ -16,12 +16,82 @@ paths:
           schema:
             type: string
             format: uri
+        - name: synctex
+          in: query
+          required: false
+          description: Whether to build the document using SyncTeX: 1 for true, and 0 for false.
+          schema:
+            type: integer
       responses:
         '200':
           description: The document was successfully built.
         '400':
           description: The request did not specify a .tex file.
-        '404':
+        '403':
           description: The request specified a file that does not exist.
         '500':
           description: The compilation steps for building the pdf had an error.
+  /latex/synctex/{filePath}:
+    get:
+      summary: Get a mapping between the text file and the compiled pdf.
+      parameters:
+        - name: filePath
+          in: path
+          required: true
+          description: The path of the .tex or .pdf file to map. If the path ends in .tex it gets the forward synchronization. If the path ends in .pdf it gets the revers synchronization.
+          schema:
+            type: string
+            format: uri
+        - name: line
+          in: query
+          required: false
+          description: The line of the text file for forwards synchronization.
+          schema:
+            type: integer
+        - name: column
+          in: query
+          required: false
+          description: The column of the text file for forwards synchronization.
+          schema:
+            type: integer
+        - name: page
+          in: query
+          required: false
+          description: The page of the PDF file for reverse synchronization.
+          schema:
+            type: integer
+        - name: x
+          in: query
+          required: false
+          description: The x position on the page (in pts) of the PDF file for reverse synchronization.
+          schema:
+            type: number
+        - name: y
+          in: query
+          required: false
+          description: The y position on the page (in pts) of the PDF file for reverse synchronization.
+          schema:
+            type: number
+      responses:
+        '200':
+          description: The SyncTeX mapping was successful.
+          schema:
+            type: object
+            description: The mapping between the .tex and .pdf documents.
+            properties:
+              x:
+                type: number
+              y:
+                type: number
+              page:
+                type: integer
+              line:
+                type: integer
+              column:
+                type: integer
+        '400':
+          description: The request did not specify a .tex or .pdf file.
+        '403':
+          description: The request specified a file that did not exist, or the .synctex.gz file did not exist.
+        '500':
+          description: The SyncTeX mapping had an error.

--- a/jupyterlab_latex/api/api.yaml
+++ b/jupyterlab_latex/api/api.yaml
@@ -38,7 +38,7 @@ paths:
         - name: filePath
           in: path
           required: true
-          description: The path of the .tex or .pdf file to map. If the path ends in .tex it gets the forward synchronization. If the path ends in .pdf it gets the revers synchronization.
+          description: The path of the .tex or .pdf file to map. If the path ends in .tex it gets the forward synchronization. If the path ends in .pdf it gets the reverse synchronization.
           schema:
             type: string
             format: uri

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@types/react": "~16.0.19",
     "@types/react-dom": "~16.0.2",
     "rimraf": "^2.5.2",
-    "typescript": "~2.4.1"
+    "typescript": "~2.6.2"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@jupyterlab/application": "^0.15.0",
     "@jupyterlab/apputils": "^0.15.0",
+    "@jupyterlab/codeeditor": "^0.15.0",
     "@jupyterlab/coreutils": "^1.0.2",
     "@jupyterlab/docmanager": "^0.15.0",
     "@jupyterlab/docregistry": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lib/*/*.js",
     "lib/*.d.ts",
     "lib/*.js",
+    "schema/*.json",
     "style/*.*"
   ],
   "directories": {
@@ -20,7 +21,8 @@
     "latex"
   ],
   "jupyterlab": {
-    "extension": "lib/index.js"
+    "extension": "lib/index.js",
+    "schemaDir": "schema"
   },
   "scripts": {
     "build": "tsc",
@@ -39,6 +41,7 @@
     "@jupyterlab/fileeditor": "^0.15.0",
     "@jupyterlab/services": "^1.0.2",
     "@phosphor/coreutils": "^1.3.0",
+    "@phosphor/disposable": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.5.0",
     "pdfjs-dist": "2.0.104",

--- a/sample.tex
+++ b/sample.tex
@@ -42,4 +42,13 @@ And we can include images, such as the Jupyter logo:
   \includegraphics[width=0.65\textwidth]{images/jupyter_logo.png}
 \end{center}
 
+
+
+\pagebreak
+
+
+
+
+You can also use SyncTeX by typing ⌘(CMD)+⇧(SHIFT)+X.
+
 \end{document}

--- a/sample.tex
+++ b/sample.tex
@@ -49,6 +49,6 @@ And we can include images, such as the Jupyter logo:
 
 
 
-You can also use SyncTeX by typing ⌘(CMD)+⇧(SHIFT)+X.
+You can also use SyncTeX by typing ⌘(CMD)/CTRL+⇧(SHIFT)+X.
 
 \end{document}

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -1,0 +1,16 @@
+{
+  "jupyter.lab.setting-icon-class": "jp-FileIcon",
+  "jupyter.lab.setting-icon-label": "LaTeX",
+  "title": "LaTeX",
+  "description": "LaTeX settings.",
+  "properties": {
+    "synctex": {
+      "type": "boolean",
+      "title": "SyncTeX",
+      "description": "Whether to use SyncTeX for linking document views",
+      "default": true
+    }
+  },
+  "additionalProperties": false,
+  "type": "object"
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,9 +66,8 @@ const latexPlugin: JupyterLabPlugin<void> = {
  *
  * @returns a Promise resolved with the JSON response.
  */
-export
-function latexRequest(url: string, settings: ServerConnection.ISettings): Promise<any> {
-  let fullUrl = URLExt.join(settings.baseUrl, 'latex', url);
+function latexBuildRequest(path: string, settings: ServerConnection.ISettings): Promise<any> {
+  let fullUrl = URLExt.join(settings.baseUrl, 'latex', 'build', path);
 
   return ServerConnection.makeRequest(fullUrl, {}, settings).then(response => {
     if (response.status !== 200) {
@@ -159,7 +158,7 @@ function activateLatexPlugin(app: JupyterLab, manager: IDocumentManager, editorT
         return;
       }
       pending = true;
-      latexRequest(texContext.path, serverSettings).then(() => {
+      latexBuildRequest(texContext.path, serverSettings).then(() => {
         // Read the pdf file contents from disk.
         pdfContext ? pdfContext.revert() : findOpenOrRevealPDF();
         if (errorPanel) {
@@ -180,7 +179,7 @@ function activateLatexPlugin(app: JupyterLab, manager: IDocumentManager, editorT
 
     // Run an initial latexRequest so that the appropriate files exist,
     // then open them.
-    latexRequest(texContext.path, serverSettings).then(() => {
+    latexBuildRequest(texContext.path, serverSettings).then(() => {
       // Open the pdf and get a handle on its document context.
       findOpenOrRevealPDF();
     }).catch((err) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,8 +163,8 @@ function synctexEditRequest(path: string, pos: ISynctexEditOptions, settings: Se
     }
     return response.json().then(json => {
       return {
-        line: parseInt(json.Line, 10),
-        column: parseInt(json.Column, 10)
+        line: parseInt(json.line, 10),
+        column: parseInt(json.column, 10)
       } as ISynctexViewOptions;
     });
   });
@@ -191,7 +191,7 @@ function synctexViewRequest(path: string, pos: ISynctexViewOptions, settings: Se
     }
     return response.json().then(json => {
       return {
-        page: parseInt(json.Page, 10),
+        page: parseInt(json.page, 10),
         x: parseFloat(json.x),
         y: parseFloat(json.y)
       } as ISynctexEditOptions;

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -92,6 +92,16 @@ class PDFJSViewer extends Widget implements DocumentRegistry.IReadyWidget {
   }
 
   /**
+   * Set the scroll
+   */
+  setScroll(pos: PDFJSViewer.IPosition): void {
+    console.log(pos);
+    this._pdfViewer.scrollPageIntoView({
+      pageNumber: pos.page
+    });
+  }
+
+  /**
    * Dispose of the resources held by the pdf widget.
    */
   dispose() {
@@ -234,6 +244,36 @@ class PDFJSViewerFactory extends ABCWidgetFactory<PDFJSViewer, DocumentRegistry.
    */
   protected createNewWidget(context: DocumentRegistry.IContext<DocumentRegistry.IModel>): PDFJSViewer {
     return new PDFJSViewer(context);
+  }
+}
+
+/**
+ * A namespace for PDFJSViewer statics.
+ */
+export
+namespace PDFJSViewer {
+  /**
+   * The options for a SyncTeX edit command,
+   * mapping the pdf position to an editor position.
+   */
+  export
+  interface IPosition {
+    /**
+     * The page of the pdf.
+     */
+    page: number;
+
+    /**
+     * The x-position on the page, in pts, where
+     * the PDF is assumed to be 72dpi.
+     */
+    x: number;
+
+    /**
+     * The y-position on the page, in pts, where
+     * the PDF is assumed to be 72dpi.
+     */
+    y: number;
   }
 }
 

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -92,13 +92,21 @@ class PDFJSViewer extends Widget implements DocumentRegistry.IReadyWidget {
   }
 
   /**
-   * Set the scroll
+   * Get the scroll position.
+   */
+  getScroll(): PDFJSViewer.IPosition {
+    return {
+      page: this._pdfViewer.currentPageNumber,
+      x: 0,
+      y: 0
+    };
+  }
+
+  /**
+   * Set the scroll position.
    */
   setScroll(pos: PDFJSViewer.IPosition): void {
-    console.log(pos);
-    this._pdfViewer.scrollPageIntoView({
-      pageNumber: pos.page
-    });
+    this._pdfViewer.currentPageNumber = pos.page;
   }
 
   /**
@@ -291,6 +299,7 @@ namespace Private {
     let pdf = document.createElement('div');
     pdf.className = PDF_CLASS;
     node.appendChild(pdf);
+    node.tabIndex = -1;
     return node;
   }
 


### PR DESCRIPTION
Basic support for SyncTex, fixes #56 :
1. Adds a new `latex/synctex` endpoint that takes the current position of one of the `.tex` or `.pdf` documents in the query parameters, and returns the position of the other.
2. Moves the existing build endpoint to `latex/build`
3. Adds context menu items to scroll the documents.
4. Adds a keyboard shortcut (currently `[Accel Shift X]`, for no particular reason) to scroll the documents.
5. SyncTeX is optional, configurable from the client-side.
