### PR TITLE
Pin PDFJS until 2.0-final is released.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.5.0",
-    "pdfjs-dist": "^2.0.104",
+    "pdfjs-dist": "2.0.104",
     "react": "~16.0.0",
     "react-dom": "~16.0.0"
   },


### PR DESCRIPTION
PDFJS broke semver yesterday, and people trying to install this extension will not be able to open PDFs with the most recent version. We should publish a patch release ASAP with this fix. Once 2.0-final is released, we can update with the new APIs (it should be pretty straightforward).

cc @mpacer 