### PR TITLE
Disable PDF open or reveal to avoid error 404 when pdflatex failed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -241,6 +241,7 @@ function activateLatexPlugin(
     let pdfContext: DocumentRegistry.IContext<DocumentRegistry.IModel>;
     let errorPanel: ErrorPanel | null = null;
     let pending = false;
+	let disableOpenOrReveal = false;
 
     const findOpenOrRevealPDF = () => {
       let pdfWidget = manager.findWidget(pdfFilePath);
@@ -314,6 +315,7 @@ function activateLatexPlugin(
             errorPanel.close();
           }
           pending = false;
+		  disableOpenOrReveal = false;
         })
         .catch(err => {
           // If there was an error, show the error panel
@@ -322,6 +324,7 @@ function activateLatexPlugin(
             errorPanelInit(err);
           }
           pending = false;
+		  disableOpenOrReveal = true;
         });
     };
 
@@ -330,7 +333,9 @@ function activateLatexPlugin(
     // Run an initial latexRequest so that the appropriate files exist,
     // then open them.
     onFileChanged().then(() => {
-      findOpenOrRevealPDF();
+	  if (!disableOpenOrReveal) {
+		findOpenOrRevealPDF();
+	  }
     });
 
     const cleanupPreviews = () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,7 +241,6 @@ function activateLatexPlugin(
     let pdfContext: DocumentRegistry.IContext<DocumentRegistry.IModel>;
     let errorPanel: ErrorPanel | null = null;
     let pending = false;
-	let disableOpenOrReveal = false;
 
     const findOpenOrRevealPDF = () => {
       let pdfWidget = manager.findWidget(pdfFilePath);
@@ -315,7 +314,6 @@ function activateLatexPlugin(
             errorPanel.close();
           }
           pending = false;
-		  disableOpenOrReveal = false;
         })
         .catch(err => {
           // If there was an error, show the error panel
@@ -324,7 +322,6 @@ function activateLatexPlugin(
             errorPanelInit(err);
           }
           pending = false;
-		  disableOpenOrReveal = true;
         });
     };
 
@@ -333,7 +330,7 @@ function activateLatexPlugin(
     // Run an initial latexRequest so that the appropriate files exist,
     // then open them.
     onFileChanged().then(() => {
-	  if (!disableOpenOrReveal) {
+	  if (!errorPanel) {
 		findOpenOrRevealPDF();
 	  }
     });


### PR DESCRIPTION
These changes seem to fix the error panel bug #80 for me. 

The cleanup line `pdfContext.disposed.connect(cleanupPreviews)` in the function `findOpenOrRevealPDF()` was closing the error panel when the `pdfContext` was disposed because the PDF was not found, I guess... Therefore, everytime a pdflatex error occurs, I disable `findOpenOrRevealPDF()` in `onFileChanged()`.

Not sure this is the best way to do, it might be better to directly change the `cleanupPreviews()` function...