### PR TITLE
Add a page number widget to the PDF viewer toolbar

### DIFF
--- a/src/pagenumber.tsx
+++ b/src/pagenumber.tsx
@@ -1,0 +1,137 @@
+import { ReactElementWidget } from '@jupyterlab/apputils';
+
+import * as React from 'react';
+
+interface IProps {
+  viewer: any;
+}
+
+interface IState {
+  currentPageLabel?: string;
+  currentPageNumber: number;
+  pagesCount: number;
+  hasLabels: boolean;
+}
+
+class PageNumberComponent extends React.Component<IProps, IState> {
+  public state: IState = {
+    currentPageNumber: 0,
+    hasLabels: false,
+    pagesCount: 0
+  };
+
+  componentDidMount() {
+    const { viewer } = this.props;
+    viewer.eventBus.on('pagechanging', this.handlePageChanging);
+    viewer.eventBus.on('pagelabels', this.handlePageLabels);
+    viewer.eventBus.on('firstpage', this.handleFirstPage);
+  }
+
+  componentWillUnmount() {
+    const { viewer } = this.props;
+    viewer.eventBus.off('pagechanging', this.handlePageChanging);
+    viewer.eventBus.off('pagelabels', this.handlePageLabels);
+    viewer.eventBus.off('firstpage', this.handleFirstPage);
+  }
+
+  handleFirstPage = () => {
+    const { viewer } = this.props;
+    const { currentPageLabel, currentPageNumber, pagesCount } = viewer;
+    const hasLabels = currentPageLabel ? true : false;
+
+    this.setState({
+      currentPageLabel,
+      currentPageNumber,
+      hasLabels,
+      pagesCount
+    });
+  };
+
+  handlePageLabels = () => {
+    const { viewer } = this.props;
+    const { currentPageLabel } = viewer;
+    this.setState({ currentPageLabel, hasLabels: true });
+  };
+
+  handlePageChanging = (evt: any) =>
+    this.setState({
+      currentPageLabel: evt.pageLabel,
+      currentPageNumber: evt.pageNumber
+    });
+
+  handleChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = evt.target;
+    if (this.state.hasLabels) {
+      this.setState({ currentPageLabel: value });
+    } else {
+      this.setState({ currentPageNumber: parseInt(value) });
+    }
+  };
+
+  handleFocus = (evt: React.FocusEvent<HTMLInputElement>) => {
+    evt.target.select();
+  };
+
+  handleBlur = (evt: React.FocusEvent<HTMLInputElement>) => {
+    const { value } = evt.target;
+    this.setCurrentPage(value);
+  };
+
+  handleKeyDown = (evt: React.KeyboardEvent<HTMLInputElement>) => {
+    if (evt.key === 'Enter') {
+      const { value } = evt.target as HTMLInputElement;
+      this.setCurrentPage(value);
+    }
+  };
+
+  setCurrentPage(pageLabel: string) {
+    const { viewer } = this.props;
+    viewer.currentPageLabel = pageLabel;
+
+    // Ensure that the page number input displays the correct value, even if the
+    // value entered by the user was invalid (e.g. a floating point number).
+    if (
+      pageLabel !== viewer.currentPageNumber.toString() &&
+      pageLabel !== viewer.currentPageLabel
+    ) {
+      const { currentPageLabel, currentPageNumber } = viewer;
+      this.setState({ currentPageLabel, currentPageNumber });
+    }
+  }
+
+  render() {
+    const {
+      currentPageLabel,
+      currentPageNumber,
+      hasLabels,
+      pagesCount
+    } = this.state;
+    const value = hasLabels ? currentPageLabel : currentPageNumber;
+    const text = hasLabels
+      ? ` (${currentPageNumber} of ${pagesCount})`
+      : ` of ${pagesCount}`;
+    return (
+      <div className="jp-PDFJSPageNumber">
+        <span>
+          <input
+            value={value}
+            onBlur={this.handleBlur}
+            onChange={this.handleChange}
+            onFocus={this.handleFocus}
+            onKeyDown={this.handleKeyDown}
+          />
+          <span>{text}</span>
+        </span>
+      </div>
+    );
+  }
+}
+
+/**
+ * Phosphor Widget version of PageNumberComponent.
+ */
+export class PageNumberWidget extends ReactElementWidget {
+  constructor(props: IProps) {
+    super(<PageNumberComponent {...props} />);
+  }
+}

--- a/src/pagenumber.tsx
+++ b/src/pagenumber.tsx
@@ -2,81 +2,100 @@ import { ReactElementWidget } from '@jupyterlab/apputils';
 
 import * as React from 'react';
 
+/**
+ * React properties for page number component.
+ */
 interface IProps {
+  /**
+   * The PDF viewer.
+   */
   viewer: any;
 }
 
+/**
+ * React state for page number component.
+ */
 interface IState {
+  /**
+   * The label of the current page.
+   */
   currentPageLabel?: string;
+
+  /**
+   * The index of the current page in the document.
+   */
   currentPageNumber: number;
+
+  /**
+   * The number of pages of the document.
+   */
   pagesCount: number;
-  hasLabels: boolean;
+
+  /**
+   * The string inserted by user in the input element.
+   */
+  userInput: string | null;
 }
 
+/**
+ * Page number React component.
+ */
 class PageNumberComponent extends React.Component<IProps, IState> {
   public state: IState = {
     currentPageNumber: 0,
-    hasLabels: false,
-    pagesCount: 0
+    pagesCount: 0,
+    userInput: null
   };
 
+  /**
+   * Start listening PDF viewer events.
+   */
   componentDidMount() {
-    const { viewer } = this.props;
-    viewer.eventBus.on('pagechanging', this.handlePageChanging);
-    viewer.eventBus.on('pagelabels', this.handlePageLabels);
-    viewer.eventBus.on('firstpage', this.handleFirstPage);
+    const { eventBus } = this.props.viewer;
+    eventBus.on('firstpage', this.handlePageDataChange);
+    eventBus.on('pagechanging', this.handlePageDataChange);
+    eventBus.on('pagelabels', this.handlePageDataChange);
   }
 
+  /**
+   * Stop listening PDF viewer events.
+   */
   componentWillUnmount() {
-    const { viewer } = this.props;
-    viewer.eventBus.off('pagechanging', this.handlePageChanging);
-    viewer.eventBus.off('pagelabels', this.handlePageLabels);
-    viewer.eventBus.off('firstpage', this.handleFirstPage);
+    const { eventBus } = this.props.viewer;
+    eventBus.off('firstpage', this.handlePageDataChange);
+    eventBus.off('pagechanging', this.handlePageDataChange);
+    eventBus.off('pagelabels', this.handlePageDataChange);
   }
 
-  handleFirstPage = () => {
-    const { viewer } = this.props;
-    const { currentPageLabel, currentPageNumber, pagesCount } = viewer;
-    const hasLabels = currentPageLabel ? true : false;
-
-    this.setState({
-      currentPageLabel,
-      currentPageNumber,
-      hasLabels,
-      pagesCount
-    });
-  };
-
-  handlePageLabels = () => {
-    const { viewer } = this.props;
-    const { currentPageLabel } = viewer;
-    this.setState({ currentPageLabel, hasLabels: true });
-  };
-
-  handlePageChanging = (evt: any) =>
-    this.setState({
-      currentPageLabel: evt.pageLabel,
-      currentPageNumber: evt.pageNumber
-    });
-
+  /**
+   * If user modifies the input value, store that text in `userInput` state
+   * property.
+   */
   handleChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
-    const { value } = evt.target;
-    if (this.state.hasLabels) {
-      this.setState({ currentPageLabel: value });
-    } else {
-      this.setState({ currentPageNumber: parseInt(value) });
-    }
+    const userInput = evt.target.value;
+    this.setState({ userInput });
   };
 
+  /**
+   * Handle input element focus.
+   */
   handleFocus = (evt: React.FocusEvent<HTMLInputElement>) => {
     evt.target.select();
   };
 
+  /**
+   * When the input element loses focus, change current page according to the
+   * input value.
+   */
   handleBlur = (evt: React.FocusEvent<HTMLInputElement>) => {
     const { value } = evt.target;
     this.setCurrentPage(value);
   };
 
+  /**
+   * If `Enter` key is pressed, change current page according to the input
+   * value.
+   */
   handleKeyDown = (evt: React.KeyboardEvent<HTMLInputElement>) => {
     if (evt.key === 'Enter') {
       const { value } = evt.target as HTMLInputElement;
@@ -84,32 +103,49 @@ class PageNumberComponent extends React.Component<IProps, IState> {
     }
   };
 
+  /**
+   * Update the state when page data change.
+   */
+  handlePageDataChange = () => {
+    const { viewer } = this.props;
+    const { currentPageLabel, currentPageNumber, pagesCount } = viewer;
+
+    this.setState({
+      currentPageLabel,
+      currentPageNumber,
+      pagesCount,
+      userInput: null
+    });
+  };
+
+  /**
+   * Change current page.
+   */
   setCurrentPage(pageLabel: string) {
     const { viewer } = this.props;
     viewer.currentPageLabel = pageLabel;
-
-    // Ensure that the page number input displays the correct value, even if the
-    // value entered by the user was invalid (e.g. a floating point number).
-    if (
-      pageLabel !== viewer.currentPageNumber.toString() &&
-      pageLabel !== viewer.currentPageLabel
-    ) {
-      const { currentPageLabel, currentPageNumber } = viewer;
-      this.setState({ currentPageLabel, currentPageNumber });
-    }
+    // Reset user input.
+    this.setState({ userInput: null });
   }
 
+  /**
+   * Render page number widget.
+   */
   render() {
     const {
       currentPageLabel,
       currentPageNumber,
-      hasLabels,
-      pagesCount
+      pagesCount,
+      userInput
     } = this.state;
-    const value = hasLabels ? currentPageLabel : currentPageNumber;
-    const text = hasLabels
+    const text = currentPageLabel
       ? ` (${currentPageNumber} of ${pagesCount})`
       : ` of ${pagesCount}`;
+    const value =
+      userInput !== null
+        ? userInput
+        : currentPageLabel || currentPageNumber.toString();
+
     return (
       <div className="jp-PDFJSPageNumber">
         <span>

--- a/style/index.css
+++ b/style/index.css
@@ -38,6 +38,30 @@
   height: 100%;
 }
 
+.jp-PDFJSPageNumber {
+  display: flex;
+  align-items: center;
+  padding: 0 6px;
+}
+
+.jp-PDFJSPageNumber input {
+  border: 1px solid var(--jp-border-color0);
+  background-color: var(--jp-input-background);
+  padding: 0 6px;
+  text-align: right;
+  width: 8ch;
+}
+
+.jp-PDFJSPageNumber input:hover {
+  background-color: var(--jp-input-hover-background);
+}
+
+.jp-PDFJSPageNumber input:focus {
+  background-color: var(--jp-input-active-background);
+  border: 1px solid var(--jp-input-active-border-color);
+  box-shadow: var(--jp-input-box-shadow);
+}
+
 [data-theme-light='true'] .jp-PreviousIcon {
   background-image: url(previous_light.svg);
 }

--- a/style/index.css
+++ b/style/index.css
@@ -47,6 +47,7 @@
 .jp-PDFJSPageNumber input {
   border: 1px solid var(--jp-border-color0);
   background-color: var(--jp-input-background);
+  color: var(--jp-ui-font-color0);
   padding: 0 6px;
   text-align: right;
   width: 8ch;


### PR DESCRIPTION
This PR adds a widget to the PDF viewer toolbar showing the current page index and number (if different from index). Moreover, it can be used to jump to specific page.

Cheers.