### PR TITLE
Run twice so hyperref and tableofcontents work.

### DIFF
--- a/jupyterlab_latex/build.py
+++ b/jupyterlab_latex/build.py
@@ -115,6 +115,8 @@ class LatexBuildHandler(APIHandler):
                 full_latex_sequence,
                 full_latex_sequence,
                 ]
+        else:
+            command_sequence += [full_latex_sequence]
 
         return command_sequence
 

--- a/jupyterlab_latex/build.py
+++ b/jupyterlab_latex/build.py
@@ -33,6 +33,7 @@ def latex_cleanup(workdir='.', whitelist=None, greylist=None):
     """
     orig_work_dir = os.getcwd()
     os.chdir(os.path.abspath(workdir))
+    cleanup_setting = True # ...cleanup from plugin.json...
 
     keep_files = set()
     for fp in greylist:
@@ -47,9 +48,10 @@ def latex_cleanup(workdir='.', whitelist=None, greylist=None):
                                   set(whitelist if whitelist else [])
                                   )
     yield
-    after = set(glob.glob("*"))
-    for fn in set(after-keep_files):
-        os.remove(fn)
+    if cleanup_setting:
+        after = set(glob.glob("*"))
+        for fn in set(after-keep_files):
+            os.remove(fn)
     os.chdir(orig_work_dir)
 
 
@@ -108,6 +110,7 @@ class LatexBuildHandler(APIHandler):
             )
 
         command_sequence = [full_latex_sequence]
+        run_times = 1 #...runtimes from plugin.json...
 
         if run_bibtex:
             command_sequence += [
@@ -115,8 +118,8 @@ class LatexBuildHandler(APIHandler):
                 full_latex_sequence,
                 full_latex_sequence,
                 ]
-        else:
-            command_sequence += [full_latex_sequence]
+        elif run_times:
+            command_sequence += [full_latex_sequence]*(run_times-1)
 
         return command_sequence
 

--- a/jupyterlab_latex/build.py
+++ b/jupyterlab_latex/build.py
@@ -177,7 +177,7 @@ class LatexBuildHandler(APIHandler):
         # Parse the path into the base name and extension of the file
         tex_file_path = os.path.join(self.notebook_dir, path.strip('/'))
         tex_base_name, ext = os.path.splitext(os.path.basename(tex_file_path))
-		c = LatexConfig(config=self.config)
+        c = LatexConfig(config=self.config)
 
         if not os.path.exists(tex_file_path):
             self.set_status(403)

--- a/jupyterlab_latex/config.py
+++ b/jupyterlab_latex/config.py
@@ -23,5 +23,5 @@ class LatexConfig(Configurable):
         'to disallow all shell escapes')
     run_times = Integer(default_value=1, config=True,
         help='How many times to compile the ".tex" files.')
-    cleanup_setting = Bool(default_value=True, config=True,
+    cleanup = Bool(default_value=True, config=True,
         help='Whether to clean up ".out/.aux" files or not.')

--- a/jupyterlab_latex/config.py
+++ b/jupyterlab_latex/config.py
@@ -1,6 +1,6 @@
 """ JupyterLab LaTex : live LaTeX editing for JupyterLab """
 
-from traitlets import Unicode, CaselessStrEnum
+from traitlets import Unicode, CaselessStrEnum, Integer, Bool
 from traitlets.config import Configurable
 
 class LatexConfig(Configurable):
@@ -21,3 +21,7 @@ class LatexConfig(Configurable):
         'Can be "restricted", for restricted shell escapes, '+\
         '"allow", to allow all shell escapes, or "disallow", '+\
         'to disallow all shell escapes')
+    run_times = Integer(default_value=1, config=True,
+        help='How many times to compile the ".tex" files.')
+    cleanup_setting = Bool(default_value=True, config=True,
+        help='Whether to clean up ".out/.aux" files or not.')

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -9,19 +9,6 @@
       "title": "SyncTeX",
       "description": "Whether to use SyncTeX for linking document views",
       "default": true
-    },
-    "cleanup": {
-      "type": "boolean",
-      "title": "Clean up",
-      "description": "Whether to clean up the .out/.aux or not",
-      "default": true
-    },
-    "runtimes": {
-      "type": "integer",
-      "title": "Run multiple times",
-      "description": "Specify how many times to run",
-      "minimum": 1,
-      "default": 1
     }
   },
   "additionalProperties": false,

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -9,6 +9,19 @@
       "title": "SyncTeX",
       "description": "Whether to use SyncTeX for linking document views",
       "default": true
+    },
+    "cleanup": {
+      "type": "boolean",
+      "title": "Clean up",
+      "description": "Whether to clean up the .out/.aux or not",
+      "default": true
+    },
+    "runtimes": {
+      "type": "integer",
+      "title": "Run multiple times",
+      "description": "Specify how many times to run",
+      "minimum": 1,
+      "default": 1
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
Since the .out/.aux and other files are deleted every time, hyperref and other things depending on these don't work. With this commit pdflatex (or whatever is used) runs twice (similar to when run_bibtex=true), so the files are there during the second run.
Of course this has an impact on performance, an alternative might be to compile into a different directory, keep all the files and only copy the .pdf back.