### PR TITLE
Fix the wrong path of synctex command

### DIFF
--- a/jupyterlab_latex/synctex.py
+++ b/jupyterlab_latex/synctex.py
@@ -83,7 +83,7 @@ class LatexSynctexHandler(APIHandler):
             c.synctex_command,
             'edit',
             '-o',
-            f'{pos["page"]}:{pos["x"]}:{pos["y"]}:{pdf_name+".pdf"}'
+            f'{pos["page"]}:{pos["x"]}:{pos["y"]}:{self.notebook_dir}/{pdf_name+".pdf"}'
             )
 
         return cmd


### PR DESCRIPTION
When the root directory of the jupyter is specified, using an incomplete path here will generate an error, "SyncTex command `synctex edit -o 1:0:0:incomplete/path/bare_jrnl .pdf` errored with code: 255"