### PR TITLE
Resolve "can't resolve 'worker-loader'" error related to pdfjs-dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@lumino/domutils": "^1.1.3",
     "@lumino/messaging": "^1.2.3",
     "@lumino/widgets": "^1.8.0",
-    "pdfjs-dist": "^2.0.943",
+    "pdfjs-dist": "2.0.943",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   },


### PR DESCRIPTION
Hi All,

I created this PR based on a comment [here](https://github.com/jupyterlab/jupyterlab-latex/issues/135) by @ian-r-rose 

This PR consists of a single change to `package.json`:
- pin v2.0.943 of pdfjs-dist

Originally I made this change locally so my team could install jupyterlab-latex as a custom extension, but I figured the community would appreciate this in the official extension even if it's a temporary fix.

If there is any protocol/standard I didn't adhere to in this PR please let me know.

Cheers,
Scott

**Install output:**
```
jupyter labextension install . --log-leve=DEBUG
Searching ['/Users/ScottWeitzner/dev/jupyterlab-latex', '/Users/ScottWeitzner/.jupyter', '/Users/ScottWeitzner/anaconda3/envs/notebook-env/etc/jupyter', '/usr/local/etc/jupyter', '/etc/jupyter'] for config files
Looking for jupyter_config in /etc/jupyter
Looking for jupyter_config in /usr/local/etc/jupyter
Looking for jupyter_config in /Users/ScottWeitzner/anaconda3/envs/notebook-env/etc/jupyter
Looking for jupyter_config in /Users/ScottWeitzner/.jupyter
Looking for jupyter_config in /Users/ScottWeitzner/dev/jupyterlab-latex
Node v12.16.3

> node /Users/ScottWeitzner/anaconda3/envs/notebook-env/lib/python3.7/site-packages/jupyterlab/staging/yarn.js install
\yarn install v1.15.2
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
warning "@jupyterlab/application > @jupyterlab/ui-components@2.0.0" has incorrect peer dependency "react@~16.9.0".
warning " > pdfjs-dist@2.0.943" has unmet peer dependency "webpack@^3.0.0 || ^4.0.0-alpha.0 || ^4.0.0".
warning "pdfjs-dist > worker-loader@2.0.0" has unmet peer dependency "webpack@^3.0.0 || ^4.0.0-alpha.0 || ^4.0.0".
[4/4] Building fresh packages...
success Saved lockfile.
Done in 11.42s.

> /usr/local/bin/npm pack /Users/ScottWeitzner/dev/jupyterlab-latex
|npm notice 
npm notice 📦  @jupyterlab/latex@2.0.0
npm notice === Tarball Contents === 
npm notice 1.5kB LICENSE                 
npm notice 2.6kB style/index.css         
npm notice 2.2kB package.json            
npm notice 401B  schema/plugin.json      
npm notice 3.0kB README.md               
npm notice 600B  style/fit_dark.svg      
npm notice 600B  style/fit_light.svg     
npm notice 213B  style/next_dark.svg     
npm notice 213B  style/next_light.svg    
npm notice 210B  style/previous_dark.svg 
npm notice 210B  style/previous_light.svg
npm notice 450B  style/zoom_in_dark.svg  
```

**Testing Evidence:**
<img width="953" alt="latex_screenshot" src="https://user-images.githubusercontent.com/10327538/85928364-6b10b780-b87a-11ea-8ad2-a1633afd290f.png">
