### PR TITLE
Update documentation and Binder with c.LatexConfig.run_times

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ by setting
 c.LatexConfig.bib_command = '<custom_bib_command>'
 ```
 
+To render references (`\ref{...}`), such as equation or chapter numbers, you would
+need to compile in multiple passes by setting
+
+```python
+c.LatexConfig.run_times = 2
+```
+
 ### Security and customizing shell escapes
 
 LaTeX files have the ability to run arbitrary code by triggering external

--- a/binder/jupyter_notebook_config.py
+++ b/binder/jupyter_notebook_config.py
@@ -1,0 +1,1 @@
+c.LatexConfig.run_times = 2

--- a/binder/start
+++ b/binder/start
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+import sys
+import shutil
+import os
+
+argv = sys.argv[1:] + ['--config', 'binder/jupyter_notebook_config.py']
+print(argv)
+
+with open('startup_args.txt', 'w') as fid:
+    fid.write(str(argv))
+
+os.execv(shutil.which(argv[0]), argv)

--- a/sample.tex
+++ b/sample.tex
@@ -22,6 +22,7 @@ We can write equations:
 \begin{equation}
     \rho \left( \frac{\partial \mathbf{u}}{\partial t} + \mathbf{u} \cdot \nabla \mathbf{u} \right) =
     -\nabla P + \eta \nabla^2 \mathbf{u} + \rho \mathbf{g}.
+\label{eq:Navier–Stokes}
 \end{equation}
 \\
 \\
@@ -35,6 +36,8 @@ And we can write tables:
     \hline
   \end{tabular}
 \end{center}
+
+We can reference equations by their numbers, i.e. Equation (\ref{eq:Navier–Stokes}).
 
 \subsection{We can add new subsections}
 And we can include images, such as the Jupyter logo:


### PR DESCRIPTION
This setting allows references `\ref{...}` to be rendered correctly instead of `??`.

Modifies the Binder to run in that mode. 
Modifies the sample.tex example to add a refence to the equation.

Solves #122 