### PR TITLE
Fix a bug of synctex edit command

### DIFF
--- a/jupyterlab_latex/synctex.py
+++ b/jupyterlab_latex/synctex.py
@@ -79,11 +79,13 @@ class LatexSynctexHandler(APIHandler):
         """
         c = LatexConfig(config=self.config)
 
+        pdf_path = os.path.join(self.notebook_dir, pdf_name+".pdf")
+
         cmd = (
             c.synctex_command,
             'edit',
             '-o',
-            f'{pos["page"]}:{pos["x"]}:{pos["y"]}:{self.notebook_dir}/{pdf_name+".pdf"}'
+            f'{pos["page"]}:{pos["x"]}:{pos["y"]}:{pdf_path}'
             )
 
         return cmd


### PR DESCRIPTION
This PR would be a solution for the following issues:

- #186 
- #200

Their problem are occured when the `notebook_dir` is a blank, because the generated path is an absolute path from the root: e.g. '/sample.tex'.

NOTE: This is a same solution of the implementation in `build_synctex_view_cmd()` function.

https://github.com/jupyterlab/jupyterlab-latex/blob/77beeb8b19a08a43f03d02113db5c36eb3874c4c/jupyterlab_latex/synctex.py#L108-L118