### PR TITLE
Make extension compatible with custom drives

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -335,7 +335,13 @@ function activateLatexPlugin(
         return Promise.resolve(void 0);
       }
       pending = true;
-      return latexBuildRequest(texContext!.path, synctex, serverSettings)
+
+      /** Get the local file path without any drive prefix potentially added by
+       * other extensions like jupyter-collaboration
+       */
+      const localPath = app.serviceManager.contents.localPath(texContext!.path);
+
+      return latexBuildRequest(localPath, synctex, serverSettings)
         .then(() => {
           // Read the pdf file contents from disk.
           pdfContext ? pdfContext.revert() : findOpenOrRevealPDF();


### PR DESCRIPTION
* Fixes [v4.0 does not work in collaborative session in jlab 4 #224](https://github.com/jupyterlab/jupyterlab-latex/issues/224)
* Similar to https://github.com/jupyter-server/jupyter-scheduler/pull/541
  * I decided to not check specifically for `RTC` custom drive to work with all possible custom drives