### PR TITLE
Fix type of `synctex_command` in configuration 

### DIFF
--- a/jupyterlab_latex/config.py
+++ b/jupyterlab_latex/config.py
@@ -16,7 +16,7 @@ class LatexConfig(Configurable):
         help='The BibTeX command to use when compiling ".tex" files.' +\
              'Only used if disable_bibtex is not set to True')
     synctex_command = Unicode('synctex', config=True,
-        help='Whether to use the synctex command when syncronizing between .tex and .pdf files.')
+        help='The synctex command to use when syncronizing between .tex and .pdf files.')
     shell_escape = CaselessStrEnum(['restricted', 'allow', 'disallow'],
         default_value='restricted', config=True,
         help='Whether to allow shell escapes '+\

--- a/jupyterlab_latex/config.py
+++ b/jupyterlab_latex/config.py
@@ -15,7 +15,7 @@ class LatexConfig(Configurable):
     bib_command = Unicode('bibtex', config=True,
         help='The BibTeX command to use when compiling ".tex" files.' +\
              'Only used if disable_bibtex is not set to True')
-    synctex_command = Bool('synctex', config=True,
+    synctex_command = Unicode('synctex', config=True,
         help='Whether to use the synctex command when syncronizing between .tex and .pdf files.')
     shell_escape = CaselessStrEnum(['restricted', 'allow', 'disallow'],
         default_value='restricted', config=True,


### PR DESCRIPTION
Dear maintainers,

Using this extension, which I've found very useful, I've encountered an issue similar to #186 and #200.

The log server reports the following error
```
raise TraitError(e)
    traitlets.traitlets.TraitError: The 'synctex_command' trait of a LatexConfig instance expected a boolean, not the str 'synctex'.
```

This pull request addresses the issue changing the traitlets type of 'synctex_command'.
I believe this fixes  #186 and fixes #200 as I was able to verify locally.

Thank you for considering it.