### PR TITLE
Change default value for `cleanup` to False in `latex_cleanup`

### DIFF
--- a/jupyterlab_latex/build.py
+++ b/jupyterlab_latex/build.py
@@ -21,6 +21,9 @@ def latex_cleanup(cleanup=False, workdir='.', whitelist=None, greylist=None):
     Parameters
     ----------
 
+    cleanup = bool, default=False
+        Whether to clean up files that were not in the working directory
+        or not.
     workdir = string, optional
         This represents a path to the working directory for running LaTeX (the
         default is '.').

--- a/jupyterlab_latex/build.py
+++ b/jupyterlab_latex/build.py
@@ -12,7 +12,7 @@ from .config import LatexConfig
 from .util import run_command
 
 @contextmanager
-def latex_cleanup(cleanup=True, workdir='.', whitelist=None, greylist=None):
+def latex_cleanup(cleanup=False, workdir='.', whitelist=None, greylist=None):
     """Context manager for changing directory and removing files when done.
 
     By default it works in the current directory, and removes all files that

--- a/jupyterlab_latex/config.py
+++ b/jupyterlab_latex/config.py
@@ -26,8 +26,8 @@ class LatexConfig(Configurable):
         'to disallow all shell escapes')
     run_times = Integer(default_value=1, config=True,
         help='How many times to compile the ".tex" files.')
-    cleanup = Bool(default_value=True, config=True,
-        help='Whether to clean up ".out/.aux" files or not.')
+    cleanup = Bool(default_value=False, config=True,
+        help='Whether to clean up files that were not in the working directory or not.')
     # Add a new configuration option to hold user-defined commands
     manual_cmd_args = TraitletsList(Unicode(), default_value=[], config=True,
         help='A list of user-defined command-line arguments with placeholders for ' +


### PR DESCRIPTION
Dear maintainers,

I'm planning to use this extension in production together with jupyterlab-git.
In this pull request I'm suggesting to change the default value of `cleanup` in the `latex_cleanup` context manager to `False`: I believe this is a safer default solution (see #158, #124).

Thank you for considering it.