### PR TITLE
Remove cleanup working directory changes; always use absolute paths.

### DIFF
--- a/jupyterlab_latex/synctex.py
+++ b/jupyterlab_latex/synctex.py
@@ -123,7 +123,7 @@ class LatexSynctexHandler(APIHandler):
 
 
     @gen.coroutine
-    def run_synctex(self, cmd):
+    def run_synctex(self, cmd, working_directory):
         """Run commands sequentially, returning a 500 code on an error.
 
         Parameters
@@ -145,8 +145,8 @@ class LatexSynctexHandler(APIHandler):
           there.
 
         """
-        self.log.debug(f'jupyterlab-latex: run: {" ".join(cmd)} (CWD: {os.getcwd()})')
-        code, output = yield run_command(cmd)
+        self.log.debug(f'jupyterlab-latex: run: {" ".join(cmd)} (CWD: {working_directory})')
+        code, output = yield run_command(cmd, working_directory)
         if code != 0:
             self.set_status(500)
             self.log.error((f'SyncTex command `{" ".join(cmd)}` '
@@ -194,7 +194,7 @@ class LatexSynctexHandler(APIHandler):
         else:
             cmd, pos = self.build_synctex_cmd(relative_base_path, ext)
 
-            out = yield self.run_synctex(cmd)
+            out = yield self.run_synctex(cmd, workdir)
             out = json.dumps(parse_synctex_response(out, pos))
         self.finish(out)
 

--- a/jupyterlab_latex/util.py
+++ b/jupyterlab_latex/util.py
@@ -6,7 +6,7 @@ from tornado import gen
 from tornado.process import Subprocess, CalledProcessError
 
 @gen.coroutine
-def run_command_sync(cmd):
+def run_command_sync(cmd, working_directory):
     """
     Run a command using the synchronous `subprocess.run`.
     The asynchronous `run_command_async` should be preferred,
@@ -22,7 +22,7 @@ def run_command_sync(cmd):
     A tuple containing the (return code, stdout)
     """
     try:
-        process = subprocess.run(cmd, stdout=subprocess.PIPE)
+        process = subprocess.run(cmd, stdout=subprocess.PIPE, cwd=working_directory)
     except subprocess.CalledProcessError as err:
         pass
     code = process.returncode
@@ -30,7 +30,7 @@ def run_command_sync(cmd):
     return (code, out)
 
 @gen.coroutine
-def run_command_async(cmd):
+def run_command_async(cmd, working_directory):
     """
     Run a command using the asynchronous `tornado.process.Subprocess`.
 
@@ -45,7 +45,8 @@ def run_command_async(cmd):
     """
     process = Subprocess(cmd,
                          stdout=Subprocess.STREAM,
-                         stderr=Subprocess.STREAM)
+                         stderr=Subprocess.STREAM,
+                         cwd=working_directory)
     try:
         yield process.wait_for_exit()
     except CalledProcessError as err:


### PR DESCRIPTION
The cleanup routines, and some other locations, relied on persistent changes to the working directory despite being in the context of yields where other changes might take place.  This may be at fault for #249, for example, and generally seems unsafe.

In an attempt to prevent the working directory from being a problem, this PR removes all `os.chdir` calls.  It instead passes paths between methods, making them absolute on the first opportunity, and sets the working directories of subprocesses at the point of starting them.  The cleanup mechanism still feels risky – it would be safer to restrict removals to a set of plausible temporary file patterns – but this should at least make things a bit safer, and doesn't involve needing to choose that set yet; I might try to come up with that later if I have time.

I'm leaving this as a draft until I can test it.
